### PR TITLE
Persist trained models and add retraining options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,8 @@ trading_alerts.txt
 stock_alerts.log
 *.csv
 *.json
-!config.json 
+!config.json
+models/
 
 # Reports and generated analysis files
 reports/*.txt

--- a/configs/config.json
+++ b/configs/config.json
@@ -55,5 +55,7 @@
         "max_daily_change": 0.02,
         "max_intraday_change": 0.015,
         "confidence_dampening": 0.5
-    }
-} 
+    },
+    "model_path": "models",
+    "retrain_interval_hours": 24
+}


### PR DESCRIPTION
## Summary
- save trained Keras models to configurable `models/<ticker>.h5` files
- load existing models on predictor startup and skip training until retrain interval elapses
- add `model_path` and `retrain_interval_hours` configuration options and ignore generated models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f434ca8488327b9118d972feea235